### PR TITLE
Fix Typo in 'normal' Size Type String

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,6 +19,6 @@ export function formatBytes(
   const accurateSizes = ["Bytes", "KiB", "MiB", "GiB", "TiB"]
   if (bytes === 0) return "0 Byte"
   const i = Math.floor(Math.log(bytes) / Math.log(1024))
-  return `${(bytes / Math.pow(1024, i)).toFixed(decimals)} ${sizeType === "accurate" ? accurateSizes[i] ?? "Bytest" : sizes[i] ?? "Bytes"
+return `${(bytes / Math.pow(1024, i)).toFixed(decimals)} ${sizeType === 'accurate' ? accurateSizes[i] ?? 'Bytes' : sizes[i] ?? 'Bytes'}`
     }`
 }


### PR DESCRIPTION
Correct the typo in the string returned for the 'normal' size type when the sizeType is 'accurate'. The string 'Bytest' is incorrect and needs to be fixed.