### PR TITLE
Change 'decoded' Variable Type from 'any' to Specific Type

### DIFF
--- a/src/middleware/api/api-middleware.tsx
+++ b/src/middleware/api/api-middleware.tsx
@@ -15,7 +15,7 @@ export default async function isAuthenticated(token: string | undefined): Promis
 
     try {
         // Verify the token
-        const decoded: any = jwt.decode(token);
+interface DecodedToken { email: string; } const decoded: DecodedToken | null = jwt.decode(token);
         if (decoded && typeof decoded === 'object' && decoded.email) {
             try {
                 const response = await api.post('/auth', { email: decoded.email });


### PR DESCRIPTION
The type of the variable 'decoded' is currently declared as 'any', which can lead to runtime errors if the structure of the decoded token is not as expected. To prevent these errors, the type should be changed to a more specific type that matches the expected structure of the decoded token.