### PR TITLE
Handle Errors in Logout API Call

### DIFF
--- a/src/components/layoutparts/navbar.tsx
+++ b/src/components/layoutparts/navbar.tsx
@@ -17,7 +17,15 @@ export default function NavBar() {
 
     const { user, setUser } = useAuthStore()
     const router = useRouter()
-    async function logoutApi() {
+async function logoutApi() {
+    try {
+        const response = await api.post('/logout')
+        return response.data
+    } catch (error) {
+        console.error('Logout API error:', error);
+        throw error;
+    }
+}
         const response = await api.post('/logout')
         return response.data
     }


### PR DESCRIPTION
The API call to logout does not handle potential errors that may arise from the request, which could lead to unhandled promise rejections.